### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 falcon==1.2.0
 inflect==0.2.5
-librosa==0.5.1
+librosa==0.7.1
 scipy==1.0.0
 Unidecode==0.4.21
 pandas


### PR DESCRIPTION
Librosa version 1.5.0 will cause bugs during run prepare_data.py.
Librosa version 1.7.0 is ok.
![image](https://user-images.githubusercontent.com/6771821/68767086-0e4ded00-065b-11ea-9173-5bbf1deb8a64.png)
